### PR TITLE
Accelerate nonnegative RGCCA solves with projected FISTA

### DIFF
--- a/fdaPDE/src/models/rgcca/blocks.h
+++ b/fdaPDE/src/models/rgcca/blocks.h
@@ -609,7 +609,12 @@ protected:
                 nn_weights_pending_warm_start_.reset();
             }
         }
-        return nn_weights_solver_->solve(z);
+        try {
+            return nn_weights_solver_->solve(z);
+        } catch (::fdapde::internals::NonNegativeWeightKKTFailure& error) {
+            error.set_block_context(h() + 1, name(), lambda_weights());
+            throw;
+        }
     }
     void reset_nonnegative_weight_solver_() {
         nn_weights_solver_.reset();

--- a/fdaPDE/src/models/rgcca/bootstrap_utils.h
+++ b/fdaPDE/src/models/rgcca/bootstrap_utils.h
@@ -354,6 +354,10 @@ void RGCCA<SamplingStrategy>::run_bootstrap_stream_(
 
                 if (committed.nn_solver_failed) {
                     bootstrap_state.nn_solver_failed = true;
+                    bootstrap_state.nn_solver_failure = std::move(committed.nn_solver_failure);
+                    bootstrap_state.nn_solver_failure_candidate_id = committed_id;
+                    bootstrap_state.nn_solver_failure_design_epoch =
+                        bootstrap_state.design_epoch;
                     bootstrap_state.stop = true;
                     stop.store(true, std::memory_order_release);
                     completed.clear();
@@ -542,12 +546,12 @@ auto RGCCA<SamplingStrategy>::fit_bootstrap_sample_(
         fit_result.emplace(fit_component_(
             boot_blocks.refs, C_active, true, fit_max_iter, cancelled, false
         ));
-    } catch (const std::runtime_error& error) {
+    } catch (const ::fdapde::internals::NonNegativeWeightKKTFailure& error) {
         const auto fit_end = std::chrono::high_resolution_clock::now();
         out.fit_time = std::chrono::duration<double>(fit_end - fit_start).count();
         out.nn_stats = ::fdapde::internals::NonNegativeWeightSolver::thread_stats() - nn_stats_before;
-        if (!is_nonnegative_coordinate_descent_failure_(error)) throw;
         out.nn_solver_failed = true;
+        out.nn_solver_failure = error;
         clear_row_index_all_(boot_blocks.refs);
         return out;
     }

--- a/fdaPDE/src/models/rgcca/logging.h
+++ b/fdaPDE/src/models/rgcca/logging.h
@@ -235,13 +235,27 @@ void RGCCA<SamplingStrategy>::log_bootstrap_lambda_summary_(
                 static_cast<double>(timing_summary.nn_stats.coordinate_attempts) : 0.0;
         fdapde::cout << "  NN solves: calls=" << timing_summary.nn_stats.calls
                      << ", direct=" << timing_summary.nn_stats.direct_sides
-                     << ", coordinate=" << timing_summary.nn_stats.coordinate_converged
+                     << ", constrained=" << timing_summary.nn_stats.coordinate_converged
                      << "/" << timing_summary.nn_stats.coordinate_attempts
-                     << ", closed_form=" << timing_summary.nn_stats.closed_form_sides << '\n';
-        fdapde::cout << "  NN coordinate: avg_sweeps=" << std::fixed << std::setprecision(1)
-                     << avg_sweeps << std::defaultfloat
+                     << ", closed_form=" << timing_summary.nn_stats.closed_form_sides
                      << ", Horst_boundary=" << timing_summary.nn_stats.horst_boundaries
                      << ", would_fallback=" << timing_summary.nn_stats.would_fallback << '\n';
+        if (timing_summary.nn_stats.coordinate_sweeps > 0) {
+            fdapde::cout << "  NN PSOR prefix: avg_sweeps=" << std::fixed
+                         << std::setprecision(1) << avg_sweeps << std::defaultfloat << '\n';
+        }
+        if (timing_summary.nn_stats.accelerated_attempts > 0) {
+            const double avg_accelerated_iterations =
+                static_cast<double>(timing_summary.nn_stats.accelerated_iterations) /
+                static_cast<double>(timing_summary.nn_stats.accelerated_attempts);
+            fdapde::cout << "  NN projected FISTA: converged="
+                         << timing_summary.nn_stats.accelerated_converged << "/"
+                         << timing_summary.nn_stats.accelerated_attempts
+                         << ", avg_iterations=" << std::fixed << std::setprecision(1)
+                         << avg_accelerated_iterations << std::defaultfloat
+                         << ", restarts=" << timing_summary.nn_stats.accelerated_restarts
+                         << '\n';
+        }
     }
 
     // design and criterion recap

--- a/fdaPDE/src/models/rgcca/model.h
+++ b/fdaPDE/src/models/rgcca/model.h
@@ -63,6 +63,38 @@ public:
     using SamplingDomain = std::conditional_t<std::same_as<SamplingStrategy, TimeDependentSampling>, Triangulation<1, 1>, internals::empty_t>;
     using ComponentCallback = std::function<void(RGCCA&, const Result&)>;
 
+    struct NonNegativeWeightFailureCapsule {
+        std::string stage;
+        int component = -1;
+        int lambda_index = -1;
+        double lambda = std::numeric_limits<double>::quiet_NaN();
+        int candidate_id = -1;
+        unsigned seed = 0;
+        int design_epoch = -1;
+        BoolMatrix active_design;
+        ::fdapde::internals::NonNegativeWeightKKTFailure solver;
+
+        NonNegativeWeightFailureCapsule(
+            std::string stage_,
+            const int component_,
+            const int lambda_index_,
+            const double lambda_,
+            const int candidate_id_,
+            const unsigned seed_,
+            const int design_epoch_,
+            const BoolMatrix& active_design_,
+            const ::fdapde::internals::NonNegativeWeightKKTFailure& solver_
+        ) : stage(std::move(stage_)),
+            component(component_),
+            lambda_index(lambda_index_),
+            lambda(lambda_),
+            candidate_id(candidate_id_),
+            seed(seed_),
+            design_epoch(design_epoch_),
+            active_design(active_design_),
+            solver(solver_) {}
+    };
+
     // constructors
     template <typename S = SamplingStrategy>
     requires std::same_as<S, IndependentSampling>
@@ -199,6 +231,7 @@ public:
         // room for results
         std::vector<Result> results;
         results.reserve(n_comp());
+        first_nonnegative_weight_failure_.reset();
         bootstrap_selection_results_.clear();
         bootstrap_selection_results_.reserve(n_comp());
         const auto initial_block_variance = block_variance_trace_(main_blocks_());
@@ -239,15 +272,29 @@ public:
                     component_result = fit_component_(blocks, C_active);
                     log_step_end_(step_start);
                     break;
-                } catch (const std::runtime_error& error) {
+                } catch (const ::fdapde::internals::NonNegativeWeightKKTFailure& error) {
                     log_step_end_(step_start);
                     if (
-                        !automatic_weight_lambda || !selection.lambda_selected ||
-                        !is_nonnegative_coordinate_descent_failure_(error)
+                        !automatic_weight_lambda || !selection.lambda_selected
                     ) throw;
 
                     const double failed_lambda = selection.lambda;
                     const auto configured_grid = lambda_grid_weights_[h_];
+                    const auto failed_it = std::find(
+                        configured_grid.begin(), configured_grid.end(), failed_lambda
+                    );
+                    const int failed_lambda_i = failed_it == configured_grid.end() ? -1 :
+                        static_cast<int>(std::distance(configured_grid.begin(), failed_it));
+                    record_nonnegative_weight_failure_(
+                        "final_fit",
+                        error,
+                        failed_lambda_i,
+                        failed_lambda,
+                        -1,
+                        bootstrap_config_.seed + h_,
+                        -1,
+                        C_active
+                    );
                     std::vector<double> lower_grid;
                     for (const double lambda : configured_grid) {
                         if (lambda < failed_lambda) lower_grid.push_back(lambda);
@@ -259,6 +306,7 @@ public:
                     }
 
                     fdapde::cout << "  Final fit failed at lambda " << failed_lambda
+                                 << ": " << error.what()
                                  << "; retrying lower lambda candidates\n";
                     bootstrap_selection_results_.pop_back();
                     lambda_grid_weights_[h_] = std::move(lower_grid);
@@ -375,6 +423,10 @@ public:
 
     // bootstrap results
     [[nodiscard]] const std::vector<BootstrapResult>& bootstrap_selection_results() const { return bootstrap_selection_results_; }
+    [[nodiscard]] const std::optional<NonNegativeWeightFailureCapsule>&
+    first_nonnegative_weight_failure() const {
+        return first_nonnegative_weight_failure_;
+    }
     void clear_bootstrap_selection_results() {
         bootstrap_selection_results_.clear();
         bootstrap_selection_results_.shrink_to_fit();
@@ -445,6 +497,9 @@ private:
             design_epoch = 0;
             stop = false;
             nn_solver_failed = false;
+            nn_solver_failure.reset();
+            nn_solver_failure_candidate_id = -1;
+            nn_solver_failure_design_epoch = -1;
             reset_accepted_samples();
         }
 
@@ -486,6 +541,9 @@ private:
         int last_connection_deactivation_check_B_done = 0;
         bool stop = false;
         bool nn_solver_failed = false;
+        std::optional<::fdapde::internals::NonNegativeWeightKKTFailure> nn_solver_failure;
+        int nn_solver_failure_candidate_id = -1;
+        int nn_solver_failure_design_epoch = -1;
 
         Eigen::MatrixXi corr_pos_count;
         Eigen::MatrixXi corr_neg_count;
@@ -611,6 +669,7 @@ private:
         bool capped = false;
         bool cancelled = false;
         bool nn_solver_failed = false;
+        std::optional<::fdapde::internals::NonNegativeWeightKKTFailure> nn_solver_failure;
         bool fit_started = false;
         ::fdapde::internals::NonNegativeWeightSolveStats nn_stats;
     };
@@ -830,13 +889,26 @@ private:
             try {
                 init_comp_(blocks, InitStrategy::None, true, &preliminary_active_blocks);
                 fit_component_(blocks, C_active);
-            } catch (const std::runtime_error& error) {
+            } catch (const ::fdapde::internals::NonNegativeWeightKKTFailure& error) {
                 preliminary_fit_seconds = elapsed_seconds(step_start);
                 log_step_end_(step_start);
-                if (!select_lambda || !is_nonnegative_coordinate_descent_failure_(error)) throw;
+                if (!select_lambda) throw;
                 boot_results.nn_solver_failed_by_lambda[preliminary_lambda_i] = true;
+                boot_results.nn_solver_failure_stage_by_lambda[preliminary_lambda_i] =
+                    "preliminary_fit";
+                boot_results.nn_solver_failure_message_by_lambda[preliminary_lambda_i] = error.what();
+                record_nonnegative_weight_failure_(
+                    "preliminary_fit",
+                    error,
+                    preliminary_lambda_i,
+                    lambda_grid[preliminary_lambda_i],
+                    -1,
+                    bootstrap_state.seed,
+                    0,
+                    C_active
+                );
                 fdapde::cout << "  Skip lambda " << lambda_grid[preliminary_lambda_i]
-                             << ": nonnegative coordinate descent did not converge\n";
+                             << ": " << error.what() << '\n';
                 continue;
             }
             preliminary_w_fit = snapshot_weights_(blocks);
@@ -887,15 +959,26 @@ private:
                 try {
                     init_comp_(blocks, InitStrategy::WarmStart, true, &active_blocks);
                     fit_component_(blocks, C_active);
-                } catch (const std::runtime_error& error) {
+                } catch (const ::fdapde::internals::NonNegativeWeightKKTFailure& error) {
                     const double warm_start_seconds = elapsed_seconds(step_start);
                     log_step_end_(step_start);
-                    if (!is_nonnegative_coordinate_descent_failure_(error)) throw;
                     boot_results.nn_solver_failed_by_lambda[lambda_i] = true;
+                    boot_results.nn_solver_failure_stage_by_lambda[lambda_i] = "warm_start_fit";
+                    boot_results.nn_solver_failure_message_by_lambda[lambda_i] = error.what();
                     boot_results.warm_start_seconds_by_lambda[lambda_i] = warm_start_seconds;
+                    record_nonnegative_weight_failure_(
+                        "warm_start_fit",
+                        error,
+                        lambda_i,
+                        lambda_grid[lambda_i],
+                        -1,
+                        bootstrap_state.seed,
+                        0,
+                        C_active
+                    );
                     copy_weights_snapshot_(blocks, last_viable_w_fit);
                     fdapde::cout << "  Skip lambda " << lambda_grid[lambda_i]
-                                 << ": nonnegative coordinate descent did not converge\n";
+                                 << ": " << error.what() << '\n';
                     C_active = reset_connections_keep_inactive_blocks_(C_initial, C_active);
                     continue;
                 }
@@ -927,6 +1010,25 @@ private:
             );
             if (bootstrap_state.nn_solver_failed) {
                 boot_results.nn_solver_failed_by_lambda[lambda_i] = true;
+                boot_results.nn_solver_failure_stage_by_lambda[lambda_i] = "bootstrap_fit";
+                boot_results.nn_solver_failure_candidate_id_by_lambda[lambda_i] =
+                    bootstrap_state.nn_solver_failure_candidate_id;
+                boot_results.nn_solver_failure_design_epoch_by_lambda[lambda_i] =
+                    bootstrap_state.nn_solver_failure_design_epoch;
+                if (bootstrap_state.nn_solver_failure) {
+                    boot_results.nn_solver_failure_message_by_lambda[lambda_i] =
+                        bootstrap_state.nn_solver_failure->what();
+                    record_nonnegative_weight_failure_(
+                        "bootstrap_fit",
+                        *bootstrap_state.nn_solver_failure,
+                        lambda_i,
+                        lambda_grid[lambda_i],
+                        bootstrap_state.nn_solver_failure_candidate_id,
+                        bootstrap_state.seed,
+                        bootstrap_state.nn_solver_failure_design_epoch,
+                        C_active
+                    );
+                }
                 boot_results.bootstrap_wall_seconds_by_lambda[lambda_i] = elapsed_seconds(start);
                 boot_results.bootstrap_fit_seconds_by_lambda[lambda_i] = bootstrap_timing_summary.fit_time;
                 boot_results.bootstrap_avg_fit_seconds_by_lambda[lambda_i] = bootstrap_timing_summary.avg_fit_time();
@@ -934,7 +1036,9 @@ private:
                 boot_results.bootstrap_max_iters_by_lambda[lambda_i] = bootstrap_timing_summary.max_iters;
                 boot_results.bootstrap_fit_count_by_lambda[lambda_i] = bootstrap_timing_summary.n_fits;
                 fdapde::cout << "  Skip lambda " << lambda_grid[lambda_i]
-                             << ": nonnegative coordinate descent did not converge\n";
+                             << ": "
+                             << boot_results.nn_solver_failure_message_by_lambda[lambda_i]
+                             << '\n';
                 C_active = reset_connections_keep_inactive_blocks_(C_initial, C_active);
                 continue;
             }
@@ -1084,6 +1188,9 @@ private:
         log_step_end_(step_start);
 
         std::vector<double> rho_null(B, std::numeric_limits<double>::quiet_NaN());
+        std::vector<std::optional<::fdapde::internals::NonNegativeWeightKKTFailure>>
+            nn_failures(n_threads);
+        std::vector<int> nn_failure_candidate_ids(n_threads, -1);
         const unsigned seed = bootstrap_config_.seed + static_cast<unsigned>(1000003 * (h_ + 1));
         const auto active_blocks = active_blocks_from_C_(C_active);
 
@@ -1107,12 +1214,15 @@ private:
 
                 // Count null statistics at least as extreme as the observed one.
                 rho_null[b] = rho_tot_maxvar_(boot_blocks.refs, C_active).normalized;
-            } catch (const std::runtime_error& error) {
+            } catch (const ::fdapde::internals::NonNegativeWeightKKTFailure& error) {
                 clear_row_index_all_(boot_blocks.refs);
+                if (!nn_failures[tid] || b < nn_failure_candidate_ids[tid]) {
+                    nn_failures[tid] = error;
+                    nn_failure_candidate_ids[tid] = b;
+                }
                 // A failed NN null refit is not a valid null draw. Leave its
                 // entry as NaN; the reported valid-null count makes this explicit.
-                if (is_nonnegative_coordinate_descent_failure_(error)) return;
-                throw;
+                return;
             } catch (...) {
                 clear_row_index_all_(boot_blocks.refs);
                 throw;
@@ -1121,6 +1231,27 @@ private:
             clear_row_index_all_(boot_blocks.refs);
         });
         log_step_end_(step_start);
+
+        int nn_failure_tid = -1;
+        int nn_failure_candidate_id = B;
+        for (int t = 0; t < n_threads; ++t) {
+            if (nn_failures[t] && nn_failure_candidate_ids[t] < nn_failure_candidate_id) {
+                nn_failure_tid = t;
+                nn_failure_candidate_id = nn_failure_candidate_ids[t];
+            }
+        }
+        if (nn_failure_tid >= 0) {
+            record_nonnegative_weight_failure_(
+                "component_significance",
+                *nn_failures[nn_failure_tid],
+                -1,
+                fixed_weight_lambda_(blocks),
+                nn_failure_candidate_id,
+                seed,
+                -1,
+                C_active
+            );
+        }
 
         std::vector<double> valid_null;
         valid_null.reserve(B);
@@ -1184,9 +1315,15 @@ private:
         }
 
         std::vector<int> significant(n_blocks(), 0);
+        const int n_threads = bootstrap_n_threads_();
+        std::vector<std::optional<::fdapde::internals::NonNegativeWeightKKTFailure>>
+            nn_failures(n_threads);
+        std::vector<int> nn_failure_block_ids(n_threads, -1);
+        std::vector<int> nn_failure_candidate_ids(n_threads, -1);
         parallel_for(0, n_blocks(), 1, [&](int j) {
             if (!testable[j]) return;
 
+            const int tid = this_thread_id();
             auto boot_blocks = clone_blocks_();
             auto* block = boot_blocks.refs[j];
             std::mt19937_64 rng(
@@ -1201,10 +1338,11 @@ private:
                 block->set_row_index(single_block_null_indices_(block->n_raw(), rng));
                 try {
                     block->compute(targets[j]);
-                } catch (const std::runtime_error& error) {
-                    if (!is_nonnegative_coordinate_descent_failure_(error)) {
-                        block->clear_row_index();
-                        throw;
+                } catch (const ::fdapde::internals::NonNegativeWeightKKTFailure& error) {
+                    if (!nn_failures[tid] || j < nn_failure_block_ids[tid]) {
+                        nn_failures[tid] = error;
+                        nn_failure_block_ids[tid] = j;
+                        nn_failure_candidate_ids[tid] = b;
                     }
                     null_test_valid = false;
                     break;
@@ -1225,6 +1363,30 @@ private:
 
         for (int j = 0; j < n_blocks(); ++j)
             out.significant[j] = significant[j] != 0;
+
+        int nn_failure_tid = -1;
+        int nn_failure_block_id = n_blocks();
+        for (int t = 0; t < n_threads; ++t) {
+            if (nn_failures[t] && nn_failure_block_ids[t] < nn_failure_block_id) {
+                nn_failure_tid = t;
+                nn_failure_block_id = nn_failure_block_ids[t];
+            }
+        }
+        if (nn_failure_tid >= 0) {
+            const unsigned seed = bootstrap_config_.seed +
+                static_cast<unsigned>(1000003 * (h_ + 1)) +
+                static_cast<unsigned>(9176 * (nn_failure_block_id + 1));
+            record_nonnegative_weight_failure_(
+                "block_importance",
+                *nn_failures[nn_failure_tid],
+                -1,
+                fixed_weight_lambda_(blocks),
+                nn_failure_candidate_ids[nn_failure_tid],
+                seed,
+                -1,
+                C_active
+            );
+        }
 
         log_block_importance_(out);
         return out;
@@ -1347,11 +1509,6 @@ private:
     }
     bool weight_lambda_selection_requested_() const {
         return opt_.lambda_selection_weights == LambdaSelection::Automatic;
-    }
-    static bool is_nonnegative_coordinate_descent_failure_(const std::runtime_error& error) {
-        return std::string_view(error.what()).starts_with(
-            "NonNegativeWeightSolver: fallback disabled; coordinate descent did not"
-        );
     }
     std::vector<double> model_selection_lambda_grid_() const {
         if (weight_lambda_selection_requested_())
@@ -1769,6 +1926,35 @@ private:
         return f;
     }
 private:
+    void record_nonnegative_weight_failure_(
+        const std::string& stage,
+        const ::fdapde::internals::NonNegativeWeightKKTFailure& error,
+        const int lambda_index,
+        const double lambda,
+        const int candidate_id,
+        const unsigned seed,
+        const int design_epoch,
+        const BoolMatrix& active_design
+    ) {
+        const auto diagnostic_stage = [](const std::string& value) {
+            return value == "component_significance" || value == "block_importance";
+        };
+        if (first_nonnegative_weight_failure_ &&
+            (!diagnostic_stage(first_nonnegative_weight_failure_->stage) || diagnostic_stage(stage)))
+            return;
+        first_nonnegative_weight_failure_.emplace(
+            stage,
+            h_ + 1,
+            lambda_index,
+            lambda,
+            candidate_id,
+            seed,
+            design_epoch,
+            active_design,
+            error
+        );
+    }
+
     Options opt_;
     DesignMode design_mode_ {DesignMode::Empty};
 
@@ -1790,6 +1976,7 @@ private:
     BootstrapConfig bootstrap_config_;
     std::vector<BootstrapResult> bootstrap_selection_results_;
     std::vector<std::vector<double>> lambda_grid_weights_;
+    std::optional<NonNegativeWeightFailureCapsule> first_nonnegative_weight_failure_;
 
     bool initialized_ {false};
     BoolMatrix C_;

--- a/fdaPDE/src/models/rgcca/types.h
+++ b/fdaPDE/src/models/rgcca/types.h
@@ -384,6 +384,10 @@ struct BootstrapResult {
     std::vector<int> B_cancelled_by_lambda;
     std::vector<int> B_final_capped_by_lambda;
     std::vector<bool> nn_solver_failed_by_lambda;
+    std::vector<std::string> nn_solver_failure_stage_by_lambda;
+    std::vector<std::string> nn_solver_failure_message_by_lambda;
+    std::vector<int> nn_solver_failure_candidate_id_by_lambda;
+    std::vector<int> nn_solver_failure_design_epoch_by_lambda;
     std::vector<int> design_epochs_by_lambda;
 
     // Reporting telemetry. Wall-clock phases are disjoint within a candidate;
@@ -440,6 +444,10 @@ struct BootstrapResult {
         B_cancelled_by_lambda.resize(n_lambda, 0);
         B_final_capped_by_lambda.resize(n_lambda, 0);
         nn_solver_failed_by_lambda.resize(n_lambda, false);
+        nn_solver_failure_stage_by_lambda.resize(n_lambda);
+        nn_solver_failure_message_by_lambda.resize(n_lambda);
+        nn_solver_failure_candidate_id_by_lambda.resize(n_lambda, -1);
+        nn_solver_failure_design_epoch_by_lambda.resize(n_lambda, -1);
         design_epochs_by_lambda.resize(n_lambda, 0);
         init_bootstrap_seconds_by_lambda.resize(n_lambda, 0.0);
         preliminary_fit_seconds_by_lambda.resize(n_lambda, 0.0);

--- a/fdaPDE/src/solvers/nonnegative_weight.h
+++ b/fdaPDE/src/solvers/nonnegative_weight.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
@@ -34,6 +35,103 @@ namespace internals {
 using Vector = Eigen::VectorXd;
 using SparseMatrix = Eigen::SparseMatrix<double, Eigen::ColMajor, int>;
 
+// Carries the exact convex NNQP state needed to reproduce a KKT failure.
+class NonNegativeWeightKKTFailure : public std::runtime_error {
+public:
+    NonNegativeWeightKKTFailure(
+        const int sweeps,
+        const int max_sweeps,
+        const int accelerated_iterations,
+        const int max_accelerated_iterations,
+        const int accelerated_restarts,
+        const double violation,
+        const double tolerance,
+        const double relaxation,
+        const double accelerated_lipschitz,
+        const Vector& c,
+        const Vector& warm_start,
+        const Vector& final_iterate,
+        const SparseMatrix& omega
+    ) : std::runtime_error(message_(
+            sweeps, accelerated_iterations, violation, tolerance
+        )),
+        sweeps_(sweeps),
+        max_sweeps_(max_sweeps),
+        accelerated_iterations_(accelerated_iterations),
+        max_accelerated_iterations_(max_accelerated_iterations),
+        accelerated_restarts_(accelerated_restarts),
+        violation_(violation),
+        tolerance_(tolerance),
+        relaxation_(relaxation),
+        accelerated_lipschitz_(accelerated_lipschitz),
+        c_(c),
+        warm_start_(warm_start),
+        final_iterate_(final_iterate),
+        omega_(omega) {}
+
+    void set_block_context(
+        const int component,
+        std::string block_name,
+        const double lambda
+    ) {
+        component_ = component;
+        block_name_ = std::move(block_name);
+        lambda_ = lambda;
+    }
+
+    [[nodiscard]] int sweeps() const { return sweeps_; }
+    [[nodiscard]] int max_sweeps() const { return max_sweeps_; }
+    [[nodiscard]] int accelerated_iterations() const { return accelerated_iterations_; }
+    [[nodiscard]] int max_accelerated_iterations() const { return max_accelerated_iterations_; }
+    [[nodiscard]] int accelerated_restarts() const { return accelerated_restarts_; }
+    [[nodiscard]] double violation() const { return violation_; }
+    [[nodiscard]] double tolerance() const { return tolerance_; }
+    [[nodiscard]] double relaxation() const { return relaxation_; }
+    [[nodiscard]] double accelerated_lipschitz() const { return accelerated_lipschitz_; }
+    [[nodiscard]] int component() const { return component_; }
+    [[nodiscard]] const std::string& block_name() const { return block_name_; }
+    [[nodiscard]] double lambda() const { return lambda_; }
+    [[nodiscard]] const char* method() const { return "projected_fista"; }
+    [[nodiscard]] const Vector& c() const { return c_; }
+    [[nodiscard]] const Vector& warm_start() const { return warm_start_; }
+    [[nodiscard]] const Vector& final_iterate() const { return final_iterate_; }
+    [[nodiscard]] const SparseMatrix& omega() const { return omega_; }
+
+private:
+    static std::string message_(
+        const int sweeps,
+        const int accelerated_iterations,
+        const double violation,
+        const double tolerance
+    ) {
+        std::ostringstream message;
+        message << "NonNegativeWeightSolver: projected FISTA did not satisfy KKT after "
+                << accelerated_iterations << " iterations";
+        if (sweeps > 0) message << " following " << sweeps << " PSOR sweeps";
+        message << " (violation="
+                << std::scientific << std::setprecision(3)
+                << violation << ", tolerance=" << tolerance << ')';
+        return message.str();
+    }
+
+    int sweeps_;
+    int max_sweeps_;
+    int accelerated_iterations_;
+    int max_accelerated_iterations_;
+    int accelerated_restarts_;
+    double violation_;
+    double tolerance_;
+    double relaxation_;
+    double accelerated_lipschitz_;
+    int component_ = -1;
+    std::string block_name_;
+    double lambda_ = std::numeric_limits<double>::quiet_NaN();
+    Vector c_;
+    Vector warm_start_;
+    Vector final_iterate_;
+    SparseMatrix omega_;
+};
+
 struct NonNegativeWeightSolveStats {
     std::uint64_t calls = 0;
     std::uint64_t zero_signals = 0;
@@ -42,6 +140,10 @@ struct NonNegativeWeightSolveStats {
     std::uint64_t coordinate_attempts = 0;
     std::uint64_t coordinate_converged = 0;
     std::uint64_t coordinate_sweeps = 0;
+    std::uint64_t accelerated_attempts = 0;
+    std::uint64_t accelerated_converged = 0;
+    std::uint64_t accelerated_iterations = 0;
+    std::uint64_t accelerated_restarts = 0;
     std::uint64_t horst_boundaries = 0;
     std::uint64_t would_fallback = 0;
 
@@ -53,6 +155,10 @@ struct NonNegativeWeightSolveStats {
         coordinate_attempts += other.coordinate_attempts;
         coordinate_converged += other.coordinate_converged;
         coordinate_sweeps += other.coordinate_sweeps;
+        accelerated_attempts += other.accelerated_attempts;
+        accelerated_converged += other.accelerated_converged;
+        accelerated_iterations += other.accelerated_iterations;
+        accelerated_restarts += other.accelerated_restarts;
         horst_boundaries += other.horst_boundaries;
         would_fallback += other.would_fallback;
         return *this;
@@ -71,6 +177,10 @@ inline NonNegativeWeightSolveStats operator-(
         lhs.coordinate_attempts - rhs.coordinate_attempts,
         lhs.coordinate_converged - rhs.coordinate_converged,
         lhs.coordinate_sweeps - rhs.coordinate_sweeps,
+        lhs.accelerated_attempts - rhs.accelerated_attempts,
+        lhs.accelerated_converged - rhs.accelerated_converged,
+        lhs.accelerated_iterations - rhs.accelerated_iterations,
+        lhs.accelerated_restarts - rhs.accelerated_restarts,
         lhs.horst_boundaries - rhs.horst_boundaries,
         lhs.would_fallback - rhs.would_fallback
     };
@@ -209,26 +319,47 @@ public:
 
             ++thread_stats_.coordinate_attempts;
             int sweeps = 0;
+            int accelerated_iterations = 0;
+            int accelerated_restarts = 0;
             double violation = std::numeric_limits<double>::infinity();
             double tolerance = 0.0;
             const Vector& warm_start = projected_direct_valid &&
                 c.dot(projected_direct_) > c.dot(solution) ? projected_direct_ : solution;
             const bool converged = try_coordinate_solution_(
-                c, warm_start, &solution, sweeps, violation, tolerance
+                c, warm_start, &solution, sweeps, accelerated_iterations,
+                accelerated_restarts, violation, tolerance
             );
             thread_stats_.coordinate_sweeps += static_cast<std::uint64_t>(sweeps);
+            if (accelerated_iterations > 0) {
+                ++thread_stats_.accelerated_attempts;
+                thread_stats_.accelerated_iterations +=
+                    static_cast<std::uint64_t>(accelerated_iterations);
+                thread_stats_.accelerated_restarts +=
+                    static_cast<std::uint64_t>(accelerated_restarts);
+            }
             if (converged) {
                 ++thread_stats_.coordinate_converged;
+                if (accelerated_iterations > 0)
+                    ++thread_stats_.accelerated_converged;
                 return true;
             }
 
             ++thread_stats_.would_fallback;
-            std::ostringstream message;
-            message << "NonNegativeWeightSolver: fallback disabled; coordinate descent did not "
-                    << "satisfy KKT after "
-                    << sweeps << " sweeps (violation=" << std::scientific << std::setprecision(3)
-                    << violation << ", tolerance=" << tolerance << ')';
-            throw std::runtime_error(message.str());
+            throw NonNegativeWeightKKTFailure(
+                sweeps,
+                coordinate_max_sweeps_,
+                accelerated_iterations,
+                accelerated_max_iterations_,
+                accelerated_restarts,
+                violation,
+                tolerance,
+                coordinate_relaxation_,
+                accelerated_lipschitz_,
+                c,
+                warm_start,
+                coordinate_x_,
+                Omega_
+            );
         };
 
         const bool positive_side_only = p.minCoeff() >= 0.0;
@@ -286,9 +417,23 @@ private:
         coordinate_x_.resize(n);
         coordinate_u_.resize(n);
         coordinate_gradient_.resize(n);
+        accelerated_y_.resize(n);
+        accelerated_next_.resize(n);
         scaled_c_.resize(n);
         bound_c_.resize(n);
         bound_solution_.resize(n);
+
+        Vector scaled_absolute_row_sum = Vector::Zero(n);
+        for (int j = 0; j < Omega_.outerSize(); ++j) {
+            for (SparseMatrix::InnerIterator it(Omega_, j); it; ++it) {
+                scaled_absolute_row_sum[it.row()] += std::abs(it.value()) *
+                    inv_sqrt_diagonal_[it.row()] * inv_sqrt_diagonal_[j];
+            }
+        }
+        accelerated_lipschitz_ = scaled_absolute_row_sum.maxCoeff() *
+            (1.0 + std::sqrt(std::numeric_limits<double>::epsilon()));
+        if (!(accelerated_lipschitz_ > 0.0) || !std::isfinite(accelerated_lipschitz_))
+            throw std::invalid_argument("NonNegativeWeightSolver: invalid accelerated Lipschitz bound");
     }
 
     void validate_omega_() const {
@@ -376,6 +521,8 @@ private:
         const Vector& warm_start,
         Vector* out,
         int& sweeps,
+        int& accelerated_iterations,
+        int& accelerated_restarts,
         double& violation,
         double& tolerance
     ) {
@@ -387,19 +534,36 @@ private:
         coordinate_u_ = sqrt_diagonal_.cwiseProduct(coordinate_x_) * warm_scale;
         coordinate_x_ = inv_sqrt_diagonal_.cwiseProduct(coordinate_u_);
 
-        coordinate_gradient_.noalias() = Omega_ * coordinate_x_;
-        coordinate_gradient_ -= c;
+        if constexpr (coordinate_max_sweeps_ > 0) {
+            coordinate_gradient_.noalias() = Omega_ * coordinate_x_;
+            coordinate_gradient_ -= c;
+        }
         scaled_c_ = inv_sqrt_diagonal_.cwiseProduct(c);
         tolerance = 1e-8 * std::max(1.0, scaled_c_.lpNorm<Eigen::Infinity>());
-        constexpr int max_sweeps = 20000;
-        constexpr int violation_check_every = 5;
-        constexpr double relaxation = 1.8;
+        constexpr int coordinate_violation_check_every = 5;
+        constexpr int accelerated_violation_check_every = 20;
+        const auto accept_solution = [&]() {
+            coordinate_x_ = inv_sqrt_diagonal_.cwiseProduct(coordinate_u_);
+            const double norm2 = coordinate_x_.dot(Omega_ * coordinate_x_);
+            if (!(norm2 > 0.0) || !std::isfinite(norm2)) return false;
+            *out = coordinate_x_ / std::sqrt(norm2);
+            return true;
+        };
+        const auto accept_solution_from_exact_gradient = [&]() {
+            const double norm2 = coordinate_x_.dot(coordinate_gradient_) +
+                coordinate_x_.dot(c);
+            if (!(norm2 > 0.0) || !std::isfinite(norm2)) return false;
+            *out = coordinate_x_ / std::sqrt(norm2);
+            return true;
+        };
 
-        for (sweeps = 1; sweeps <= max_sweeps; ++sweeps) {
+        for (sweeps = 1; sweeps <= coordinate_max_sweeps_; ++sweeps) {
             for (int i = 0; i < n; ++i) {
                 const double old_value = coordinate_u_[i];
                 const double gradient_i = coordinate_gradient_[i] * inv_sqrt_diagonal_[i];
-                const double new_value = std::max(0.0, old_value - relaxation * gradient_i);
+                const double new_value = std::max(
+                    0.0, old_value - coordinate_relaxation_ * gradient_i
+                );
                 const double delta = new_value - old_value;
                 if (delta == 0.0) continue;
 
@@ -414,7 +578,7 @@ private:
                 coordinate_gradient_.noalias() = Omega_ * coordinate_x_;
                 coordinate_gradient_ -= c;
             }
-            if (sweeps % violation_check_every != 0) continue;
+            if (sweeps % coordinate_violation_check_every != 0) continue;
 
             violation = 0.0;
             for (int i = 0; i < n; ++i) {
@@ -424,14 +588,72 @@ private:
                 violation = std::max(violation, current);
             }
             if (violation > tolerance) continue;
-
-            coordinate_x_ = inv_sqrt_diagonal_.cwiseProduct(coordinate_u_);
-            const double norm2 = coordinate_x_.dot(Omega_ * coordinate_x_);
-            if (!(norm2 > 0.0) || !std::isfinite(norm2)) return false;
-            *out = coordinate_x_ / std::sqrt(norm2);
-            return true;
+            return accept_solution();
         }
         --sweeps;
+
+        // Projected FISTA acts on the diagonally scaled NNQP, with a Gershgorin
+        // upper bound on its Lipschitz constant and deterministic gradient restart.
+        accelerated_y_ = coordinate_u_;
+        double momentum = 1.0;
+        const auto accelerated_kkt_satisfied = [&]() {
+            coordinate_x_ = inv_sqrt_diagonal_.cwiseProduct(coordinate_u_);
+            coordinate_gradient_.noalias() = Omega_ * coordinate_x_;
+            coordinate_gradient_ -= c;
+            violation = 0.0;
+            for (int i = 0; i < n; ++i) {
+                const double gradient_i = coordinate_gradient_[i] * inv_sqrt_diagonal_[i];
+                const double current = coordinate_u_[i] > 1e-14 ?
+                    std::abs(gradient_i) : std::max(0.0, -gradient_i);
+                violation = std::max(violation, current);
+            }
+            return violation <= tolerance;
+        };
+        for (accelerated_iterations = 1;
+             accelerated_iterations <= accelerated_max_iterations_;
+             ++accelerated_iterations) {
+            coordinate_x_ = inv_sqrt_diagonal_.cwiseProduct(accelerated_y_);
+            coordinate_gradient_.noalias() = Omega_ * coordinate_x_;
+            coordinate_gradient_ -= c;
+            accelerated_next_ = accelerated_y_ -
+                inv_sqrt_diagonal_.cwiseProduct(coordinate_gradient_) /
+                    accelerated_lipschitz_;
+            accelerated_next_ = accelerated_next_.cwiseMax(0.0);
+            if (!accelerated_next_.allFinite()) {
+                violation = std::numeric_limits<double>::infinity();
+                coordinate_x_ = inv_sqrt_diagonal_.cwiseProduct(coordinate_u_);
+                return false;
+            }
+
+            const double next_momentum =
+                0.5 * (1.0 + std::sqrt(1.0 + 4.0 * momentum * momentum));
+            const bool restart = (accelerated_y_ - accelerated_next_)
+                .dot(accelerated_next_ - coordinate_u_) > 0.0;
+            if (restart) {
+                ++accelerated_restarts;
+                accelerated_y_ = accelerated_next_;
+                momentum = 1.0;
+            } else {
+                accelerated_y_ = accelerated_next_ +
+                    ((momentum - 1.0) / next_momentum) *
+                        (accelerated_next_ - coordinate_u_);
+                momentum = next_momentum;
+            }
+            coordinate_u_.swap(accelerated_next_);
+            if (!accelerated_y_.allFinite()) {
+                violation = std::numeric_limits<double>::infinity();
+                coordinate_x_ = inv_sqrt_diagonal_.cwiseProduct(coordinate_u_);
+                return false;
+            }
+
+            if (accelerated_iterations % accelerated_violation_check_every != 0) continue;
+            if (accelerated_kkt_satisfied()) return accept_solution_from_exact_gradient();
+        }
+        --accelerated_iterations;
+        if (accelerated_iterations % accelerated_violation_check_every != 0 &&
+            accelerated_kkt_satisfied())
+            return accept_solution_from_exact_gradient();
+        coordinate_x_ = inv_sqrt_diagonal_.cwiseProduct(coordinate_u_);
         return false;
     }
 
@@ -464,9 +686,18 @@ private:
     Vector coordinate_x_;
     Vector coordinate_u_;
     Vector coordinate_gradient_;
+    Vector accelerated_y_;
+    Vector accelerated_next_;
     Vector scaled_c_;
     Vector bound_c_;
     Vector bound_solution_;
+
+    // Projected FISTA is the primary bounded solve; retaining PSOR sweeps here
+    // is useful only as a measured compatibility/performance trade-off.
+    static constexpr int coordinate_max_sweeps_ = 0;
+    static constexpr double coordinate_relaxation_ = 1.8;
+    static constexpr int accelerated_max_iterations_ = 25000;
+    double accelerated_lipschitz_ = 0.0;
 
     Vector x_init_;
     Vector last_solution_pos_;

--- a/test/src/rgcca.cpp
+++ b/test/src/rgcca.cpp
@@ -758,6 +758,9 @@ TEST(rgcca, nonnegative_weight_solver_finds_active_boundary_optimum) {
     EXPECT_NEAR(weights.dot(Omega * weights), 1.0, 1e-10);
     EXPECT_NEAR(z.dot(weights), 1.0 / std::sqrt(2.0), 1e-9);
     EXPECT_EQ(stats.coordinate_attempts, 1);
+    EXPECT_EQ(stats.accelerated_attempts, 1);
+    EXPECT_EQ(stats.accelerated_converged, 1);
+    EXPECT_GT(stats.accelerated_iterations, 0);
     EXPECT_EQ(stats.coordinate_converged, 1);
     EXPECT_EQ(stats.would_fallback, 0);
 }
@@ -907,7 +910,7 @@ TEST(rgcca, bootstrap_lambda_selection_probes_an_upper_boundary_once) {
     EXPECT_DOUBLE_EQ(bootstrap.front().lambda_grid[1], 10.0);
 }
 
-TEST(rgcca, automatic_nn_lambda_selection_recovers_from_component_two_initialization_failure) {
+TEST(rgcca, projected_fista_nn_solver_accepts_large_lambda_and_records_later_failure) {
     constexpr int n = 80;
     constexpr int p = 40;
     RGCCA<IndependentSampling>::Options options;
@@ -950,15 +953,72 @@ TEST(rgcca, automatic_nn_lambda_selection_recovers_from_component_two_initializa
     bootstrap_config.block_importance_resamples = 2;
     rgcca.set_bootstrap_config(bootstrap_config);
 
+    const auto stats_before = ::fdapde::internals::NonNegativeWeightSolver::thread_stats();
     const auto results = rgcca.fit();
+    const auto stats = ::fdapde::internals::NonNegativeWeightSolver::thread_stats() - stats_before;
     const auto& bootstrap = rgcca.bootstrap_selection_results();
 
     ASSERT_EQ(results.size(), 2);
     ASSERT_EQ(bootstrap.size(), 2);
     EXPECT_DOUBLE_EQ(bootstrap[0].lambda_opt, 1e5);
     EXPECT_EQ(bootstrap[1].h, 1);
-    EXPECT_TRUE(bootstrap[1].nn_solver_failed_by_lambda[1]);
+    EXPECT_FALSE(bootstrap[1].nn_solver_failed_by_lambda[1]);
+    EXPECT_TRUE(bootstrap[1].nn_solver_failure_stage_by_lambda[1].empty());
+    EXPECT_TRUE(bootstrap[1].nn_solver_failure_message_by_lambda[1].empty());
     EXPECT_DOUBLE_EQ(bootstrap[1].lambda_opt, 1e-3);
+    EXPECT_GT(stats.accelerated_attempts, 0);
+    EXPECT_GT(stats.accelerated_converged, 0);
+
+    const auto& capsule = rgcca.first_nonnegative_weight_failure();
+    ASSERT_TRUE(capsule.has_value());
+    EXPECT_EQ(capsule->stage, "block_importance");
+    EXPECT_EQ(capsule->component, 1);
+    EXPECT_EQ(capsule->lambda_index, -1);
+    EXPECT_DOUBLE_EQ(capsule->lambda, 1e5);
+    EXPECT_EQ(capsule->candidate_id, 1);
+    EXPECT_FALSE(capsule->solver.block_name().empty());
+    EXPECT_EQ(capsule->solver.component(), 1);
+    EXPECT_DOUBLE_EQ(capsule->solver.lambda(), 1e5);
+    EXPECT_STREQ(capsule->solver.method(), "projected_fista");
+    EXPECT_EQ(capsule->solver.sweeps(), 0);
+    EXPECT_EQ(capsule->solver.max_sweeps(), 0);
+    EXPECT_EQ(capsule->solver.accelerated_iterations(), 25000);
+    EXPECT_EQ(capsule->solver.max_accelerated_iterations(), 25000);
+    EXPECT_GT(capsule->solver.violation(), capsule->solver.tolerance());
+    EXPECT_GT(capsule->solver.accelerated_lipschitz(), 0.0);
+    EXPECT_TRUE(capsule->solver.c().allFinite());
+    EXPECT_TRUE(capsule->solver.warm_start().allFinite());
+    EXPECT_TRUE(capsule->solver.final_iterate().allFinite());
+    EXPECT_EQ(capsule->solver.omega().rows(), capsule->solver.c().size());
+    EXPECT_EQ(capsule->solver.omega().cols(), capsule->solver.c().size());
+    EXPECT_EQ(capsule->solver.warm_start().size(), capsule->solver.c().size());
+    EXPECT_EQ(capsule->solver.final_iterate().size(), capsule->solver.c().size());
+
+    ::fdapde::internals::SparseMatrix identity(
+        capsule->solver.c().size(), capsule->solver.c().size()
+    );
+    identity.setIdentity();
+    ::fdapde::internals::NonNegativeWeightSolver replay(
+        identity, capsule->solver.omega(), false
+    );
+    replay.reset_warm_start(capsule->solver.warm_start());
+    try {
+        (void)replay.solve(capsule->solver.c());
+        FAIL() << "Stored NNQP unexpectedly converged";
+    } catch (const ::fdapde::internals::NonNegativeWeightKKTFailure& replay_error) {
+        EXPECT_EQ(replay_error.sweeps(), capsule->solver.sweeps());
+        EXPECT_EQ(
+            replay_error.accelerated_iterations(),
+            capsule->solver.accelerated_iterations()
+        );
+        EXPECT_EQ(
+            replay_error.accelerated_restarts(),
+            capsule->solver.accelerated_restarts()
+        );
+        EXPECT_DOUBLE_EQ(replay_error.violation(), capsule->solver.violation());
+        EXPECT_DOUBLE_EQ(replay_error.tolerance(), capsule->solver.tolerance());
+    }
+
     bool nn_importance_failure_was_invalidated = false;
     for (std::size_t j = 0; j < results[0].block_importance.size(); ++j) {
         nn_importance_failure_was_invalidated |= std::isfinite(results[0].block_importance[j]) &&


### PR DESCRIPTION
## Summary

- replace the bounded PSOR fallback with diagonally scaled projected FISTA and deterministic gradient restart
- retain the direct feasible solution path and require exact KKT acceptance
- record per-thread solve statistics and exact first-failure replay capsules
- add active-boundary, orientation, large-lambda, replay, and bootstrap-reproducibility coverage

## Root cause

Large regularization values create poorly conditioned nonnegative quadratic programs. The previous coordinate iteration stalled at its sweep cap and rejected otherwise viable lambda candidates.

## Checks

- 30/30 fdaPDE core tests
- deterministic 108-case sparse SPD NNQP corpus
- local HCP lambda-1 B=20 runs at one and eight workers
- local HCP large-lambda B=5 run, including explicit rejection of the remaining 1e5 cap case
- actual `main_fRGCCA` application compile and smoke run
